### PR TITLE
Fixed a bug in haralick features which reduces runtime and prevents crashes

### DIFF
--- a/jtlibrary/python/jtlibrary/src/jtlib/features.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/features.py
@@ -437,8 +437,9 @@ class Texture(Features):
     '''
 
     def __init__(self, label_image, intensity_image,
-            theta_range=4, frequencies={1, 5, 10}, radius={1, 5, 10},
-            threshold=None, compute_haralick=False):
+                 theta_range=4, frequencies=[1, 5, 10], radius=[1, 5, 10],
+                 scales=[1], threshold=None, compute_haralick=False,
+                 compute_TAS=False, compute_LBP=False):
         '''
         Parameters
         ----------
@@ -450,14 +451,16 @@ class Texture(Features):
         theta_range: int, optional
             number of angles to define the orientations of the Gabor
             filters (default: ``4``)
-        frequencies: Set[int], optional
-            frequencies of the Gabor filters (default: ``{1, 5, 10}``)
+        frequencies: List[int], optional
+            frequencies of the Gabor filters (default: ``[1, 5, 10]``)
+        scales: List[int], optional
+            scales at which to compute the Haralick textures (default: ``[1]``)
         threshold: int, optional
             threshold value for Threshold Adjacency Statistics (TAS)
             (defaults to value computed by Otsu's method)
-        radius: Set[int], optional
+        radius: List[int], optional
             radius for defining pixel neighbourhood for Local Binary Patterns
-            (LBP) (default: ``{1, 5, 10}``)
+            (LBP) (default: ``[1, 5, 10]``)
         compute_haralick: bool, optional
             whether Haralick features should be computed
             (the computation is computationally expensive) (default: ``False``)
@@ -466,6 +469,7 @@ class Texture(Features):
         self.theta_range = theta_range
         self.frequencies = frequencies
         self.radius = radius
+        self.scales = scales
         if threshold is None:
             self._threshold = mh.otsu(intensity_image)
         else:
@@ -481,22 +485,30 @@ class Texture(Features):
             raise TypeError(
                 'Elements of argument "frequencies" must have type int.'
             )
+        if not all([isinstance(f, int) for s in self.scales]):
+            raise TypeError(
+                'Elements of argument "scales" must have type int.'
+            )
         self.compute_haralick = compute_haralick
+        self.compute_TAS = compute_TAS
+        self.compute_LBP = compute_LBP
 
     @property
     def _feature_names(self):
         names = ['Gabor-frequency-%d' % f for f in self.frequencies]
-        names.extend(['TAS-center-%d' % i for i in xrange(9)])
-        names.extend(['TAS-n-center-%d' % i for i in xrange(9)])
-        names.extend(['TAS-mu-margin-%d' % i for i in xrange(9)])
-        names.extend(['TAS-n-mu-margin-%d' % i for i in xrange(9)])
-        names.extend(['TAS-mu-%d' % i for i in xrange(9)])
-        names.extend(['TAS-n-mu-%d' % i for i in xrange(9)])
+        if self.compute_TAS:
+            names.extend(['TAS-center-%d' % i for i in xrange(9)])
+            names.extend(['TAS-n-center-%d' % i for i in xrange(9)])
+            names.extend(['TAS-mu-margin-%d' % i for i in xrange(9)])
+            names.extend(['TAS-n-mu-margin-%d' % i for i in xrange(9)])
+            names.extend(['TAS-mu-%d' % i for i in xrange(9)])
+            names.extend(['TAS-n-mu-%d' % i for i in xrange(9)])
         names.extend(['Hu-%d' % i for i in xrange(7)])
-        for r in self.radius:
-            names.extend(['LBP-radius-%d-%d' % (r, i) for i in xrange(36)])
+        if self.compute_LBP:
+            for r in self.radius:
+                names.extend(['LBP-radius-%d-%d' % (r, i) for i in xrange(36)])
         if self.compute_haralick:
-            names.extend([
+            haralick_names = [
                 'Haralick-angular-second-moment',
                 'Haralick-contrast',
                 'Haralick-correlation',
@@ -510,7 +522,9 @@ class Texture(Features):
                 'Haralick-diff-entropy',
                 'Haralick-info-measure-corr-1',
                 'Haralick-info-measure-corr-2'
-            ])
+            ]
+            for s in self.scales:
+                names.extend([h + "-" + str(s) for h in haralick_names])
         return names
 
     def extract(self):
@@ -549,37 +563,47 @@ class Texture(Features):
                     best_score = np.max([best_score, score])
                 values.append(best_score)
             # Threshold Adjacency Statistics
-            logger.debug('extract TAS features for object #%d', obj)
-            tas_values = mh.features.pftas(img, T=self._threshold)
-            values.extend(tas_values)
+            if self.compute_TAS:
+                logger.debug('extract TAS features for object #%d', obj)
+                tas_values = mh.features.pftas(img, T=self._threshold)
+                values.extend(tas_values)
             # Hu
             logger.debug('extract Hu moments for object #%d', obj)
             region = self.object_properties[obj]
             hu_values = region.weighted_moments_hu
             values.extend(hu_values)
             # Local Binary Pattern
-            logger.debug('extract Local Binary Patterns for object #%d', obj)
-            for r in self.radius:
-                # We may want to use more points, but the number of features
-                # increases exponentially with the number of neighbourhood
-                # points.
-                vals = mh.features.lbp(img, radius=r, points=8)
-                values.extend(vals)
+            if self.compute_LBP:
+                logger.debug('extract Local Binary Patterns for object #%d', obj)
+                for r in self.radius:
+                    # We may want to use more points, but the number of features
+                    # increases exponentially with the number of neighbourhood
+                    # points.
+                    vals = mh.features.lbp(img, radius=r, points=8)
+                    values.extend(vals)
             if self.compute_haralick:
                 # Haralick
-                logger.debug('extract Haralick features for object #%d', obj)
-                # NOTE: Haralick features are computed on 8-bit images.
-                clipped_img = np.clip(img, 0, self._clip_value)
-                rescaled_img = mh.stretch(clipped_img)
-                haralick_values = mh.features.haralick(
-                    img, ignore_zeros=False, return_mean=True
-                )
-                if not isinstance(haralick_values, np.ndarray):
-                    # NOTE: setting `ignore_zeros` to True creates problems for some
-                    # objects, when all values of the adjacency matrices are zeros
-                    haralick_values = np.empty((len(self.names), ), dtype=float)
-                    haralick_values[:] = np.NAN
-                values.extend(haralick_values)
+                for scale in self.scales:
+                    logger.debug('extract Haralick features for object #%d at scale %d', obj, scale)
+                    # NOTE: Haralick features are computed on 8-bit images.
+                    clipped_img = np.clip(img, 0, self._clip_value)
+                    rescaled_img = mh.stretch(clipped_img)
+                    try:
+                        haralick_values = mh.features.haralick(
+                            rescaled_img,
+                            ignore_zeros=True,
+                            return_mean=True,
+                            distance=scale
+                        )
+                    except ValueError:
+                        haralick_values[:] = np.NAN
+
+                    if not isinstance(haralick_values, np.ndarray):
+                        # NOTE: setting `ignore_zeros` to True creates problems for some
+                        # objects, when all values of the adjacency matrices are zeros
+                        haralick_values = np.empty((len(self.names), ), dtype=float)
+                        haralick_values[:] = np.NAN
+                    values.extend(haralick_values)
             features.append(values)
         return pd.DataFrame(features, columns=self.names, index=self.object_ids)
 

--- a/jtlibrary/python/jtlibrary/src/jtlib/features.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/features.py
@@ -596,6 +596,7 @@ class Texture(Features):
                             distance=scale
                         )
                     except ValueError:
+                        haralick_values = np.empty((13,),dtype=float)
                         haralick_values[:] = np.NAN
 
                     if not isinstance(haralick_values, np.ndarray):

--- a/jtlibrary/python/jtlibrary/src/jtlib/features.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/features.py
@@ -485,7 +485,7 @@ class Texture(Features):
             raise TypeError(
                 'Elements of argument "frequencies" must have type int.'
             )
-        if not all([isinstance(f, int) for s in self.scales]):
+        if not all([isinstance(s, int) for s in self.scales]):
             raise TypeError(
                 'Elements of argument "scales" must have type int.'
             )

--- a/jtlibrary/python/jtmodules/src/jtmodules/measure_texture.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/measure_texture.handles.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.0
+version: 0.3.0
 
 input:
 
@@ -34,10 +34,35 @@ input:
         case "extract_objects" and "assign_objects" have a many-to-one
         relationship aggregation must be performed.
 
+    - name: frequencies
+      type: Sequence
+      value: [1, 5, 10]
+      help: List of frequencies for Gabor filters
+
+    - name: measure_TAS
+      type: Boolean
+      value: false
+      help: Should Threshold Adjacency Statistics be extracted?
+
+    - name: measure_LBP
+      type: Boolean
+      value: false
+      help: Should Local Binary Patterns be extracted?
+
+    - name: radii
+      type: Sequence
+      value: [1, 5, 10]
+      help: List of radii for Local Binary Patterns
+
     - name: measure_haralick
       type: Boolean
       value: false
       help: Should Haralick features be extracted?
+
+    - name: scales
+      type: Sequence
+      value: [1,2]
+      help: List of scales for the Haralick features
 
     - name: plot
       type: Plot

--- a/jtlibrary/python/jtmodules/src/jtmodules/measure_texture.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/measure_texture.py
@@ -16,13 +16,17 @@ import collections
 import jtlib.features
 
 
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 
 Output = collections.namedtuple('Output', ['measurements', 'figure'])
 
 
 def main(extract_objects, assign_objects, intensity_image, aggregate,
-        measure_haralick=False, plot=False):
+         frequencies=[1,5,10],
+         measure_TAS=False,
+         measure_LBP=False, radii=[1,5,10],
+         measure_haralick=False, scales=[1,2],
+         plot=False):
     '''Measures texture features for objects in `extract_objects` based
     on grayscale values in `intensity_image` and assign them to `assign_objects`.
 
@@ -37,6 +41,18 @@ def main(extract_objects, assign_objects, intensity_image, aggregate,
     aggregate: bool, optional
         whether measurements should be aggregated in case `extract_objects`
         and `assign_objects` have a many-to-one relationship
+    frequencies: Set[int], optional
+        frequencies of the Gabor filters (default: ``{1, 5, 10}``)
+    measure_TAS: bool, optional
+        whether *Threshold Adjacency Statistics (TAS)* features should
+        be extracted
+    measure_LBP: bool, optional
+        whether *Local Binary Patterns (LBP)* should be extracted
+    radii: Set[int], optional
+        radii for defining pixel neighbourhood for Local Binary Patterns
+        (LBP) (default: ``{1, 5, 10}``)
+    scales: Set[int], optional
+        scales at which to compute the Haralick textures
     measure_haralick: bool, optional
         whether *Haralick* features should be extracted
     plot: bool, optional
@@ -51,8 +67,14 @@ def main(extract_objects, assign_objects, intensity_image, aggregate,
     :class:`jtlib.features.Texture`
     '''
     f = jtlib.features.Texture(
-        label_image=extract_objects, intensity_image=intensity_image,
-        compute_haralick=measure_haralick
+        label_image=extract_objects,
+        intensity_image=intensity_image,
+        frequencies=frequencies,
+        radius=radii,
+        scales=scales,
+        compute_haralick=measure_haralick,
+        compute_TAS=measure_TAS,
+        compute_LBP=measure_LBP
     )
 
     f.check_assignment(assign_objects, aggregate)


### PR DESCRIPTION
There was a bug in haralick features https://github.com/TissueMAPS/TissueMAPS/blob/master/jtlibrary/python/jtlibrary/src/jtlib/features.py#L575 causing a 16-bit image to be passed instead of an 8-bit image. This frequently resulted in crashes.

I also modified the call option: `ignore_zeros=False` to `ignore_zeros=True` in the haralick function call. This is the behaviour in CellProfiler https://github.com/CellProfiler/CellProfiler/blob/613247de8b9227b17f9b2eb31b43ad86682aee7d/cellprofiler/modules/measuretexture.py#L616 and most users would want to replicate this.

This PR also changes the jterator interface to expose more options. In general, texture features are expensive to compute so users should have more control over which features (and at which length scales) they want features to be calculated.

This is currently running on the latest master branch standalone instance (mimuelle) without problems.

One outstanding issue with the new interface is that passing a single argument (instead of a list of arguments) cannot be saved. This arises because the handles file now contains "sequence" type arguments (for the length scales of feature values calculations). When the handles file is parsed with a single number here, it is interpreted as a "numeric" type and results in an error, because a list is expected. In general I would prefer this to be passed to the jterator module as a list of length 1, rather than to throw an error.

I cannot quite work out how to fix this. @riccardomurri could you please have a look into this?

```
2018-10-01 12:42:48| Traceback (most recent call last):
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1997, in __call__
2018-10-01 12:42:48|     2018-10-01 12:42:48| return self.wsgi_app(environ, start_response)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1985, in wsgi_app
2018-10-01 12:42:48|     2018-10-01 12:42:48| response = self.handle_exception(e)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1540, in handle_exception
2018-10-01 12:42:48|     2018-10-01 12:42:48| reraise(exc_type, exc_value, tb)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
2018-10-01 12:42:48|     2018-10-01 12:42:48| response = self.full_dispatch_request()
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
2018-10-01 12:42:48|     2018-10-01 12:42:48| rv = self.handle_user_exception(e)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
2018-10-01 12:42:48|     2018-10-01 12:42:48| reraise(exc_type, exc_value, tb)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
2018-10-01 12:42:48|     2018-10-01 12:42:48| rv = self.dispatch_request()
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
2018-10-01 12:42:48|     2018-10-01 12:42:48| return self.view_functions[rule.endpoint](**req.view_args)
2018-10-01 12:42:48|   File "/home/tissuemaps/.local/lib/python2.7/site-packages/flask_jwt/__init__.py", line 177, in decorator
2018-10-01 12:42:48|     2018-10-01 12:42:48| return fn(*args, **kwargs)
2018-10-01 12:42:48|   File "/home/tissuemaps/TissueMAPS/tmserver/tmserver/util.py", line 137, in wrapped
2018-10-01 12:42:48|     2018-10-01 12:42:48| return f(*args, **kwargs)
2018-10-01 12:42:48|   File "/home/tissuemaps/TissueMAPS/tmserver/tmserver/util.py", line 240, in wrapped
2018-10-01 12:42:48|     2018-10-01 12:42:48| return f(*args, **kwargs)
2018-10-01 12:42:48|   File "/home/tissuemaps/TissueMAPS/tmserver/tmserver/jtui/api.py", line 118, in update_project
2018-10-01 12:42:48|     2018-10-01 12:42:48| handles_descriptions[h['name']] = HandleDescriptions(**h['description'])
2018-10-01 12:42:48|   File "/home/tissuemaps/TissueMAPS/tmlibrary/tmlib/workflow/jterator/description.py", line 573, in __init__
2018-10-01 12:42:48|     2018-10-01 12:42:48| self.input = self._create_input_descriptions(input)
2018-10-01 12:42:48|   File "/home/tissuemaps/TissueMAPS/tmlibrary/tmlib/workflow/jterator/description.py", line 632, in _create_input_descriptions
2018-10-01 12:42:48|     2018-10-01 12:42:48| (handle_type, i, str(err))
2018-10-01 12:42:48| tmlib.errors2018-10-01 12:42:48| .2018-10-01 12:42:48| PipelineDescriptionError2018-10-01 12:42:48| : 2018-10-01 12:42:48| Arguments for type "Sequence" of input item #9 in handles description are incorrect:
Argument "value" must have type list.2018-10-01 12:42:48|
```

