### PR TITLE
Improved separate clumps

### DIFF
--- a/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
@@ -242,7 +242,10 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
     '''
 
     logger.info('separate clumped objects')
-    label_image, n_objects = mh.label(clumps_image)
+    
+    # All the labeling is done with 8-connectivity (not the default 4 of mahotas)
+    se = np.ones((3,3), np.bool)
+    label_image, n_objects = mh.label(clumps_image, Bc = se)
     if n_objects == 0:
         logger.debug('no objects')
         return label_image
@@ -253,7 +256,7 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
     while True:
         logger.info('cutting pass #%d', cutting_pass)
         cutting_pass += 1
-        label_image = mh.label(label_image > 0)[0]
+        label_image = mh.label(label_image > 0, Bc = se)[0]
 
         f = Morphology(label_image)
         values = f.extract()
@@ -315,7 +318,7 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
             se = np.ones((3,3), np.bool)
             line = mh.labeled.borders(regions, Bc=se)
             line[~obj_image] = 0
-            line = mh.morph.dilate(line)
+            line = mh.morph.dilate(line, Bc=se)
 
             # Ensure that cut is reasonable given user-defined criteria
             test_cut_image = obj_image.copy()
@@ -342,4 +345,4 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
                 logger.debug('don\'t cut object #%d', oid)
                 mh.labeled.remove_regions(label_image, oid, inplace=True)
 
-    return mh.label(separated_image)[0]
+    return mh.label(separated_image, Bc = se)[0]

--- a/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 University of Zurich.
+# Copyright (C) 2017-2018 University of Zurich.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -211,6 +211,9 @@ def find_concave_regions(mask, max_dist):
     return mh.label(concave_img)
 
 
+# All the labeling is done with 8-connectivity (not the default 4 of mahotas)
+NEIGHBORHOOD8 = np.ones((3,3), np.bool)
+
 def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
         max_circularity, max_convexity):
     '''Separates objects in `clumps_image` based on morphological criteria.
@@ -242,10 +245,8 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
     '''
 
     logger.info('separate clumped objects')
-    
-    # All the labeling is done with 8-connectivity (not the default 4 of mahotas)
-    se = np.ones((3,3), np.bool)
-    label_image, n_objects = mh.label(clumps_image, Bc = se)
+
+    label_image, n_objects = mh.label(clumps_image, NEIGHBORHOOD8)
     if n_objects == 0:
         logger.debug('no objects')
         return label_image
@@ -256,7 +257,7 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
     while True:
         logger.info('cutting pass #%d', cutting_pass)
         cutting_pass += 1
-        label_image = mh.label(label_image > 0, Bc = se)[0]
+        label_image = mh.label(label_image > 0, NEIGHBORHOOD8)[0]
 
         f = Morphology(label_image)
         values = f.extract()
@@ -316,9 +317,9 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
 
             # Use the line separating watershed regions to make the cut
             se = np.ones((3,3), np.bool)
-            line = mh.labeled.borders(regions, Bc=se)
+            line = mh.labeled.borders(regions, NEIGHBORHOOD8)
             line[~obj_image] = 0
-            line = mh.morph.dilate(line, Bc=se)
+            line = mh.morph.dilate(line, NEIGHBORHOOD8)
 
             # Ensure that cut is reasonable given user-defined criteria
             test_cut_image = obj_image.copy()
@@ -345,4 +346,4 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
                 logger.debug('don\'t cut object #%d', oid)
                 mh.labeled.remove_regions(label_image, oid, inplace=True)
 
-    return mh.label(separated_image, Bc = se)[0]
+    return mh.label(separated_image, NEIGHBORHOOD8)[0]

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.2.2
 
 input:
 
@@ -57,6 +57,13 @@ input:
     help: >
       Should an alternative figure be created, which shows values for each
       of the selection criteria (area, convexity, circularity)?
+
+  - name: selection_test_show_remaining
+    type: Boolean
+    value: false
+    help: >
+      Should the values of the selection criteria of the remaining objects
+      (after performing the cuts) be shown?
 
 output:
 

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.0
+version: 0.2.1
 
 input:
 

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 University of Zurich.
+# Copyright (C) 2016-2018 University of Zurich.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,13 +83,15 @@ def main(mask, intensity_image, min_area, max_area,
 
     if plot:
         from jtlib import plotting
-        cut_mask = (mask > 0) - (separated_mask > 0)
+
         clumps_mask = np.zeros(mask.shape, bool)
         initial_objects_label_image, n_initial_objects = mh.label(mask > 0)
-        for i in range(1, n_initial_objects+1):
-            index = initial_objects_label_image == i
-            if len(np.unique(separated_mask[index])) > 1:
-                clumps_mask[index] = True
+        for n in range(1, n_initial_objects+1):
+            obj = (initial_objects_label_image == n)
+            if len(np.unique(separated_mask[obj])) > 1:
+                clumps_mask[obj] = True
+
+        cut_mask = (mask > 0) & (separated_mask == 0)
         cutlines = mh.morph.dilate(mh.labeled.bwperim(cut_mask))
 
         if selection_test_mode:

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -24,7 +24,7 @@ import collections
 from jtlib.segmentation import separate_clumped_objects
 from jtlib.features import Morphology, create_feature_image
 
-VERSION = '0.2.1'
+VERSION = '0.2.2'
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,8 @@ Output = collections.namedtuple('Output', ['separated_mask', 'figure'])
 
 def main(mask, intensity_image, min_area, max_area,
         min_cut_area, max_circularity, max_convexity,
-        plot=False, selection_test_mode=False):
+        plot=False, selection_test_mode=False, 
+        selection_test_show_remaining=False):
     '''Detects clumps in `mask` given criteria provided by the user
     and cuts them along the borders of watershed regions, which are determined
     based on the distance transform of `mask`.
@@ -64,6 +65,11 @@ def main(mask, intensity_image, min_area, max_area,
         display values of the selection criteria *area*, *circularity* and
         *convexity* for each individual object in `mask` as well as
         the selected "clumps" based on the criteria provided by the user
+    selection_test_show_remaining: bool, optional
+        whether the selection test plot should be made on the remaining image
+        after the cuts were performed (helps to see why some objects were not 
+        cut, especially if there are complicated clumps that require multiple
+        cuts). Defaults to false, thus showing the values in the original image    
 
     Returns
     -------
@@ -88,7 +94,14 @@ def main(mask, intensity_image, min_area, max_area,
 
         if selection_test_mode:
             logger.info('create plot for selection test mode')
-            labeled_mask, n_objects = mh.label(mask)
+
+            # Check if selection_test_show_remaining is active
+            # If so, show values on processed image, not original
+            if selection_test_show_remaining:
+                labeled_mask, n_objects = mh.label(separated_mask > 0)
+                logger.info('Selection test mode plot with processed image')
+            else:
+                labeled_mask, n_objects = mh.label(mask)
             f = Morphology(labeled_mask)
             values = f.extract()
             area_img = create_feature_image(
@@ -99,18 +112,6 @@ def main(mask, intensity_image, min_area, max_area,
             )
             circularity_img = create_feature_image(
                 values['Morphology_Circularity'].values, labeled_mask
-            )
-            area_colorscale = plotting.create_colorscale(
-                'Greens', n_objects,
-                add_background=True, background_color='white'
-            )
-            circularity_colorscale = plotting.create_colorscale(
-                'Blues', n_objects,
-                add_background=True, background_color='white'
-            )
-            convexity_colorscale = plotting.create_colorscale(
-                'Reds', n_objects,
-                add_background=True, background_color='white'
             )
             plots = [
                 plotting.create_float_image_plot(

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -34,7 +34,7 @@ Output = collections.namedtuple('Output', ['separated_mask', 'figure'])
 
 def main(mask, intensity_image, min_area, max_area,
         min_cut_area, max_circularity, max_convexity,
-        plot=False, selection_test_mode=False, 
+        plot=False, selection_test_mode=False,
         selection_test_show_remaining=False):
     '''Detects clumps in `mask` given criteria provided by the user
     and cuts them along the borders of watershed regions, which are determined
@@ -67,9 +67,9 @@ def main(mask, intensity_image, min_area, max_area,
         the selected "clumps" based on the criteria provided by the user
     selection_test_show_remaining: bool, optional
         whether the selection test plot should be made on the remaining image
-        after the cuts were performed (helps to see why some objects were not 
+        after the cuts were performed (helps to see why some objects were not
         cut, especially if there are complicated clumps that require multiple
-        cuts). Defaults to false, thus showing the values in the original image    
+        cuts). Defaults to false, thus showing the values in the original image
 
     Returns
     -------
@@ -132,8 +132,11 @@ def main(mask, intensity_image, min_area, max_area,
             figure = plotting.create_figure(
                 plots,
                 title=(
-                    'Selection criteria: "area" (top left), "convexity" (top-right) '
-                    'and "circularity" (bottom-left). Cuts made (bottom right)'
+                    'Selection criteria:'
+                    ' "area" (top left),'
+                    ' "convexity" (top-right),'
+                    ' and "circularity" (bottom-left);'
+                    ' cuts made (bottom right).'
                 )
             )
         else:


### PR DESCRIPTION
Improvements to the separate_clumps module in Jterator:
- Changed the library function separate_clumped_objects to perform all the labeling in 8-connectivity & perform the cuts with a 8-connectivity dilation instead of a 4 connectivity dilation. In this way, all the cuts are slightly broader and ensure that no separated objects have 8-connectivity. Thus, it solves the issue of TissueMaps loosing track of some nuclei (both would have the same label assigned, but polygon building would make two polygons and discard the smaller one, thus discarding the smaller of the two "separated" nuclei).
- Fixed plotting for the selection test mode and removed unused code for colormaps (support for using them was removed in ef4b354cafb10e8dcdbc35dd7a2b4185fec0dd42, two years ago)
- Added a feature to the selection test mode to switch between displaying the features on the original image or the final processed image
  