### PR TITLE
Fix an off-by-one error in the jterator interface

### DIFF
--- a/tmserver/tmserver/jtui/api.py
+++ b/tmserver/tmserver/jtui/api.py
@@ -232,7 +232,7 @@ def create_joblist(experiment_id):
             order_by(tm.Site.id).\
             all()
         for index, record in enumerate(query):
-            metadata[index+1] = {
+            metadata[index] = {
                 'plate': record.plate,
                 'well': record.well,
                 'y': record.y,


### PR DESCRIPTION
Jterator interface displays the Job IDs starting from 1, but expects to be given Job IDs starting from 0. This fix changes the displayed Job IDs to a zero-based indexing system as well.