### PR TITLE
Add neighbour measurement module

### DIFF
--- a/jtlibrary/python/jtlibrary/src/jtlib/features.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/features.py
@@ -360,8 +360,12 @@ class Morphology(Features):
     @property
     def _feature_names(self):
         names = [
-            'Local_Centroid_x', 'Local_Centroid_y', 'Area', 'Eccentricity', 'Convexity', 'Circularity', 'Perimeter',
-            'Elongation'
+            'Local_Centroid_x', 'Local_Centroid_y',
+            'Area', 'Perimeter', 'Eccentricity', 'Extent',
+            'Convexity', 'Circularity', 'Roundness',
+            'Elongation','Equivalent_Diameter',
+            'Major_Axis_Length','Minor_Axis_Length',
+            'Maximum_Radius','Mean_Radius'
         ]
         if self.compute_zernike:
             for n in xrange(self._degree+1):
@@ -380,29 +384,55 @@ class Morphology(Features):
         '''
         logger.info('extract morphology features')
         features = list()
-        cm = mh.center_of_mass(img=self.label_image > 0,labels=self.label_image)
+        distances = ndi.morphology.distance_transform_edt(self.label_image)
+        regionprops = measure.regionprops(
+            label_image=self.label_image,
+            intensity_image=distances)
         for obj in self.object_ids:
             mask = self.get_object_mask_image(obj)
-            local_centroid_x = cm[obj][1]
-            local_centroid_y = cm[obj][0]
-            area = np.float64(np.count_nonzero(mask))
-            perimeter = mh.labeled.perimeter(mask)
+            roundness = mh.features.roundness(mask)
+
+            # skimage ignores label = 0 and starts list of objects at n=1
+            sk_obj = obj - 1
+
+            # calculate centroid, area and perimeter for selected object
+            local_centroid_x = regionprops[sk_obj].centroid[1]
+            local_centroid_y = regionprops[sk_obj].centroid[0]
+            area = regionprops[sk_obj].area
+            perimeter = regionprops[sk_obj].perimeter
+            extent = regionprops[sk_obj].extent
+
+            # calculate circularity (a.k.a. form factor)
             if perimeter == 0:
                 circularity = np.nan
             else:
                 circularity = (4.0 * np.pi * area) / (perimeter**2)
-            convex_hull = mh.polygon.fill_convexhull(mask)
-            area_convex_hull = np.count_nonzero(convex_hull)
-            convexity = area / area_convex_hull
-            eccentricity = mh.features.eccentricity(mask)
-            major_axis, minor_axis = mh.features.ellipse_axes(mask)
+
+            # calculate convexity (a.k.a solidity)
+            area_convex_hull = regionprops[sk_obj].convex_area
+            convexity = area / float(area_convex_hull)
+
+            # calculate ellipse features
+            eccentricity = regionprops[sk_obj].eccentricity
+            equivalent_diameter = regionprops[sk_obj].equivalent_diameter
+            major_axis = regionprops[sk_obj].major_axis_length
+            minor_axis = regionprops[sk_obj].minor_axis_length
             if major_axis == 0:
                 elongation = np.nan
             else:
                 elongation = (major_axis - minor_axis) / major_axis
+
+            # calculate "distance" features
+            max_radius = regionprops[sk_obj].max_intensity
+            mean_radius = regionprops[sk_obj].mean_intensity
+
             values = [
-                local_centroid_x, local_centroid_y, area, eccentricity, convexity, circularity, perimeter,
-                elongation
+                local_centroid_x, local_centroid_y,
+                area, perimeter, eccentricity, extent,
+                convexity, circularity, roundness,
+                elongation, equivalent_diameter,
+                major_axis, minor_axis,
+                max_radius, mean_radius
             ]
             if self.compute_zernike:
                 logger.debug('extract Zernike moments for object #%d', obj)

--- a/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.handles.yaml
@@ -1,0 +1,49 @@
+---
+version: 0.0.1
+
+input:
+
+    - name: extract_objects
+      type: SegmentedObjects
+      key:
+      help: >
+        Labeled image with registered objects
+        for which intensity features should be extracted.
+
+    - name: assign_objects
+      type: SegmentedObjects
+      key:
+      help: >
+        Labeled image with registered objects to which intensity features
+        should be assigned. "extract_objects" and "assign_objects" must
+        have a one-to-one relationship
+
+    - name: neighbour_distance
+      type: Scalar
+      value: 3
+      help: >
+        Distance (in pixels) between objects to be considered neighbours
+
+    - name: touching_distance
+      type: Scalar
+      value: 3
+      help: >
+        Distance (in pixels) between objects to be considered "touching"
+
+    - name: plot
+      type: Plot
+      value: false
+      help: Should a figure be created?
+
+output:
+
+    - name: measurements
+      type: Measurement
+      objects: assign_objects
+      objects_ref: extract_objects
+      help: Extracted neighbour features.
+
+    - name: figure
+      type: Figure
+
+

--- a/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.py
@@ -1,0 +1,165 @@
+# Copyright 2019 Scott Berry, University of Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''Jterator module for measuring neighbour features.'''
+import collections
+import jtlib.features
+import logging
+import numpy as np
+import pandas as pd
+import mahotas as mh
+from scipy import ndimage as ndi
+
+VERSION = '0.0.1'
+
+Output = collections.namedtuple('Output', ['measurements', 'figure'])
+
+logger = logging.getLogger(__name__)
+
+
+class Neighbours(jtlib.features.Features):
+    '''Class for calculating neighbour features.
+    '''
+
+    def __init__(self, label_image, neighbour_distance, touching_distance):
+        '''
+        Parameters
+        ----------
+        label_image: numpy.ndarray[numpy.int32]
+            labeled image encoding objects (connected pixel components)
+            for which features should be extracted
+        '''
+        super(Neighbours, self).__init__(label_image)
+        self.neighbour_distance = neighbour_distance
+        self.touching_distance = touching_distance
+
+    @property
+    def _feature_names(self):
+        return ['Neighbours_Count', 'Neighbours_List', 'Fraction_Touching']
+
+    def get_bbox_containing_neighbours(self, object_id, pad):
+        '''Extracts the bounding box for a given object from
+        :attr:`label_image <jtlib.features.Features.label_image>`.
+
+        Returns
+        -------
+        numpy.ndarray[int32]
+            label image for given object including surrounding objects
+            of the same type
+        '''
+        bbox = self._bboxes[object_id]
+        ymin = bbox[0] - pad if bbox[0] - pad > 0 else 0
+        ymax = bbox[1] + pad if bbox[1] + pad < self.label_image.shape[0] else self.label_image.shape[0]
+        xmin = bbox[2] - pad if bbox[2] - pad > 0 else 0
+        xmax = bbox[3] + pad if bbox[3] + pad < self.label_image.shape[1] else self.label_image.shape[1]
+        img = self.label_image[ymin:ymax, xmin:xmax]
+        return img
+
+    def extract(self):
+        '''Extracts neighbour features.
+
+        Returns
+        -------
+        pandas.DataFrame
+            extracted feature values for each object in `label_image`
+        '''
+        # Create an empty dataset in case no objects were detected
+        logger.info('extract neighbour features')
+        features = list()
+
+        for obj in self.object_ids:
+            pad = max(self.neighbour_distance, self.touching_distance)
+            object_image = self.get_bbox_containing_neighbours(obj,pad)
+
+            # dilate the current object
+            object_image_dilate = mh.dilate(
+                object_image == obj,
+                Bc=mh.disk(self.neighbour_distance))
+
+            # mask the corresponding region of the label image
+            object_image_mask = np.copy(object_image)
+            object_image_mask[object_image_dilate == 0] = 0
+            object_image_mask[object_image == obj] = 0
+            neighbour_ids = np.unique(object_image_mask)
+            unique_values = neighbour_ids[np.nonzero(neighbour_ids)].tolist()
+            neighbour_count = len(unique_values)
+
+            # save these unique values as a string
+            neighbour_string = '.'.join(str(x) for x in unique_values)
+
+            # create an inverted image of the surrounding cells
+            neighbours = np.zeros_like(object_image)
+            for n in unique_values:
+                neighbours += mh.dilate(object_image == n)
+
+            # calculate the distance from each pixel of object to neighbours
+            dist = ndi.morphology.distance_transform_edt(
+                np.invert(neighbours > 0))
+
+            # select perimeter pixels whose distance to neighbours is
+            # less than threshold touching distance
+            perimeter_image = mh.bwperim(object_image == obj)
+            dist[perimeter_image == 0] = 0
+            dist[dist > self.touching_distance] = 0
+
+            fraction_touching = np.count_nonzero(dist) / float(np.count_nonzero(perimeter_image))
+
+            values = [
+                neighbour_count,
+                neighbour_string,
+                fraction_touching
+            ]
+            features.append(values)
+        return pd.DataFrame(
+            features, columns=self.names, index=self.object_ids)
+
+
+def main(extract_objects, assign_objects, neighbour_distance, touching_distance, plot=False):
+    '''Measures neighbour features for objects in `extract_objects`
+     and assigns them to `assign_objects`.
+
+    Parameters
+    ----------
+    extract_objects: numpy.ndarray[int32]
+        label image with objects for which features should be extracted
+    assign_objects: nu0mpy.ndarray[int32]
+        label image with objects to which extracted features should be assigned
+    neighbour_distance: integer
+        distance in pixels between objects to be considered "neighbours"
+    touching_distance: integer
+        distance in pixels between objects to be considered "touching"
+
+    Returns
+    -------
+    jtmodules.measure_neighbours.Output[Union[List[pandas.DataFrame], str]]
+
+    See also
+    --------
+    :class:`Neighbours`
+    '''
+
+    f = Neighbours(
+        label_image=extract_objects,
+        neighbour_distance=neighbour_distance,
+        touching_distance=touching_distance
+    )
+
+    f.check_assignment(assign_objects, aggregate=False)
+    measurements = [f.extract()]
+
+    if plot:
+        figure = f.plot()
+    else:
+        figure = str()
+
+    return Output(measurements, figure)

--- a/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/measure_neighbours.py
@@ -95,7 +95,10 @@ class Neighbours(jtlib.features.Features):
             neighbour_count = len(unique_values)
 
             # save these unique values as a string
-            neighbour_string = '.'.join(str(x) for x in unique_values)
+            if neighbour_count == 0:
+                neighbour_string = '.'
+            else:
+                neighbour_string = '.'.join(str(x) for x in unique_values)
 
             # create an inverted image of the surrounding cells
             neighbours = np.zeros_like(object_image)

--- a/tmlibrary/tmlib/models/mapobject.py
+++ b/tmlibrary/tmlib/models/mapobject.py
@@ -1,5 +1,5 @@
 # TmLibrary - TissueMAPS library for distibuted image analysis routines.
-# Copyright (C) 2016-2019 University of Zurich.
+# Copyright (C) 2016-2018 University of Zurich.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -425,12 +425,7 @@ class Mapobject(DistributedExperimentModel):
     ref_id = Column(BigInteger, index=True)
 
     #: int: ID of parent mapobject type
-    mapobject_type_id = Column(
-        Integer,
-        ForeignKey('mapobject_types.id', onupdate='CASCADE', ondelete='CASCADE'),
-        index=True,
-        nullable=False,
-    )
+    mapobject_type_id = Column(Integer, index=True, nullable=False)
 
     def __init__(self, partition_key, mapobject_type_id, ref_id=None):
         '''

--- a/tmlibrary/tmlib/workflow/jterator/api.py
+++ b/tmlibrary/tmlib/workflow/jterator/api.py
@@ -1,5 +1,5 @@
 # TmLibrary - TissueMAPS library for distibuted image analysis routines.
-# Copyright (C) 2016-2019  University of Zurich
+# Copyright (C) 2016, 2018  University of Zurich
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -231,6 +231,13 @@ class ImageAnalysisPipelineEngine(WorkflowStepAPI):
             static_types = ['Plates', 'Wells', 'Sites']
             mapobject_types = session.query(tm.MapobjectType.id).\
                 filter(~tm.MapobjectType.name.in_(static_types)).\
+                all()
+            mapobject_type_ids = [t.id for t in mapobject_types]
+            session.query(tm.Mapobject).\
+                filter(tm.Mapobject.mapobject_type_id.in_(mapobject_type_ids)).\
+                delete()
+            session.query(tm.MapobjectType).\
+                filter(tm.MapobjectType.id.in_(mapobject_type_ids)).\
                 delete()
 
     def _load_pipeline_input(self, site_id):


### PR DESCRIPTION
Module to count and get the identity of neighbouring objects. Neighbours are returned using their local segmentation labels as a period `.`-separated string as a single feature. This can be unpacked later in data analysis and is compatible with both the database hstore and csv file exports from the database. mapobject ids would obviously be better, but these are not yet assigned at the time of jterator execution. I have validated several sites manually.

The fraction of an object that is touching its neighbours is also calculated and seems to generate reasonable results when visualized as a heatmap (white low, red high).

![Screenshot 2019-03-19 at 22 44 27](https://user-images.githubusercontent.com/5407848/54644688-379d8580-4a9a-11e9-855d-f095650f9a04.png)

example output of module:
```
       Neighbours_Neighbours_Count Neighbours_Neighbours_List Neighbours_Fraction_Touching
125106                           4        2801.2818.2870.2871                            1
125107                           4        2806.2818.2855.2869                            1
125108                           3             2801.2863.2869                            1
125109                           4        2812.2827.2834.2857                            1
125110                           3             2728.2823.2850                            1
125111                           2                  2835.2865                            1
```