### PR TITLE
Improved separate clumps module

### DIFF
--- a/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
@@ -333,7 +333,7 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
             # than 2 objects created by the cut, check if they are very small.
             # If so, remove them.
             if allow_trimming and n_subobjects > 2 and smaller_object_area < trimming_threshold:
-                tiny_objects = list(np.where(sizes < trimming_threshold)[0])
+                tiny_objects = np.nonzero(sizes < trimming_threshold)[0].tolist()
                 # Remove objects by adding them to the cutting line
                 for trim_obj in tiny_objects:
                     line[subobjects == trim_obj] = True

--- a/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
@@ -27,6 +27,7 @@ def detect_blobs(image, mask, threshold, min_area, deblend_nthresh=500,
         deblend_cont=0):
     '''Detects blobs in `image` using an implementation of
     `SExtractor <http://www.astromatic.net/software/sextractor>`_ [1].
+    
     Parameters
     ----------
     image: numpy.ndarray[Union[numpy.uint8, numpy.uint16]]
@@ -43,10 +44,12 @@ def detect_blobs(image, mask, threshold, min_area, deblend_nthresh=500,
         number of deblending thresholds (default: ``500``)
     deblend_cont: int, optional
         minimum contrast ratio for deblending (default: ``0``)
+        
     Returns
     -------
     Tuple[numpy.ndarray[numpy.int32]]
         detected blobs and the corresponding centroids
+        
     References
     ----------
     .. [1] Bertin, E. & Arnouts, S. 1996: SExtractor: Software for source
@@ -100,6 +103,7 @@ def detect_blobs(image, mask, threshold, min_area, deblend_nthresh=500,
 def expand_objects_watershed(seeds_image, background_image, intensity_image):
     '''Expands objects in `seeds_image` using a watershed transform
     on `intensity_image`.
+    
     Parameters
     ----------
     seeds_image: numpy.ndarray[numpy.int32]
@@ -110,6 +114,7 @@ def expand_objects_watershed(seeds_image, background_image, intensity_image):
     intensity_image: numpy.ndarray[Union[numpy.uint8, numpy.uint16]]
         grayscale image; pixel intensities determine how far individual
         objects are expanded
+        
     Returns
     -------
     numpy.ndarray[numpy.int32]
@@ -177,6 +182,7 @@ def expand_objects_watershed(seeds_image, background_image, intensity_image):
 
 def find_concave_regions(mask, max_dist):
     '''Finds convace regions along the contour of `mask`.
+    
     Parameters
     ----------
     mask: numpy.ndarray[numpy.bool]
@@ -211,6 +217,7 @@ NEIGHBORHOOD8 = np.ones((3,3), np.bool)
 def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
         max_circularity, max_convexity, allow_trimming = True):
     '''Separates objects in `clumps_image` based on morphological criteria.
+    
     Parameters
     ----------
     clumps_image: numpy.ndarray[Union[numpy.int32, numpy.bool]]
@@ -229,6 +236,7 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
     allow_trimming: boolean
         Some cuts may create a tiny third object. If this boolean is true,
         tertiary objects < trimming_threshold (10) pixels will be removed
+        
     Returns
     -------
     numpy.ndarray[numpy.uint32]

--- a/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
+++ b/jtlibrary/python/jtlibrary/src/jtlib/segmentation.py
@@ -332,22 +332,20 @@ def separate_clumped_objects(clumps_image, min_cut_area, min_area, max_area,
             # Deal with an edge-case: If trimming is active & there are more
             # than 2 objects created by the cut, check if they are very small.
             # If so, remove them.
-            if allow_trimming:
-                if n_subobjects > 2:
-                    if smaller_object_area < trimming_threshold:
-                        tiny_objects = list(np.where(sizes < trimming_threshold)[0])
-                        # Remove objects by adding them to the cutting line
-                        for trim_obj in tiny_objects:
-                            line[subobjects == trim_obj] = True
-                            logger.debug('Trimming an object of size: {}'.format(sizes[trim_obj]))
+            if allow_trimming and n_subobjects > 2 and smaller_object_area < trimming_threshold:
+                tiny_objects = list(np.where(sizes < trimming_threshold)[0])
+                # Remove objects by adding them to the cutting line
+                for trim_obj in tiny_objects:
+                    line[subobjects == trim_obj] = True
+                    logger.debug('Trimming an object of size: {}'.format(sizes[trim_obj]))
 
-                        # Redo calculation if split should be applied
-                        test_cut_image = obj_image.copy()
-                        test_cut_image[line] = False
-                        subobjects, n_subobjects = mh.label(test_cut_image,
-                                                            NEIGHBORHOOD8)
-                        sizes = mh.labeled.labeled_size(subobjects)
-                        smaller_object_area = np.min(sizes)
+                # Redo calculation if split should be applied
+                test_cut_image = obj_image.copy()
+                test_cut_image[line] = False
+                subobjects, n_subobjects = mh.label(test_cut_image,
+                                                    NEIGHBORHOOD8)
+                sizes = mh.labeled.labeled_size(subobjects)
+                smaller_object_area = np.min(sizes)
 
 
             logger.debug('Number of objects: {}'.format(n_subobjects))

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.2
+version: 0.2.3
 
 input:
 
@@ -64,6 +64,13 @@ input:
     help: >
       Should the values of the selection criteria of the remaining objects
       (after performing the cuts) be shown?
+
+  - name: trimming
+    type: Boolean
+    value: true
+    help: >
+      Some cuts may create a tiny third object. If this boolean is true, 
+      tertiary objects < trimming_threshold (10) pixels will be removed
 
 output:
 

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.3
+version: 0.3.0
 
 input:
 

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.handles.yaml
@@ -74,9 +74,9 @@ input:
 
 output:
 
-  - name: separated_mask
-    type: MaskImage
-    key: separate_clumps.separated_mask
+  - name: separated_label_image
+    type: LabelImage
+    key: separate_clumps.separated_label_image
     help: Labeled output image with separated objects.
 
   - name: figure

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -24,7 +24,7 @@ import collections
 from jtlib.segmentation import separate_clumped_objects
 from jtlib.features import Morphology, create_feature_image
 
-VERSION = '0.2.3'
+VERSION = '0.3.0'
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ Output = collections.namedtuple('Output', ['separated_label_image', 'figure'])
 def main(mask, intensity_image, min_area, max_area,
         min_cut_area, max_circularity, max_convexity,
         plot=False, selection_test_mode=False,
-        selection_test_show_remaining=False, trimming = True):
+        selection_test_show_remaining=False, trimming=True):
     '''Detects clumps in `mask` given criteria provided by the user
     and cuts them along the borders of watershed regions, which are determined
     based on the distance transform of `mask`.
@@ -81,7 +81,7 @@ def main(mask, intensity_image, min_area, max_area,
 
     separated_label_image = separate_clumped_objects(
         mask, min_cut_area, min_area, max_area,
-        max_circularity, max_convexity, allow_trimming = trimming
+        max_circularity, max_convexity, allow_trimming=trimming
     )
 
     if plot:

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -24,7 +24,7 @@ import collections
 from jtlib.segmentation import separate_clumped_objects
 from jtlib.features import Morphology, create_feature_image
 
-VERSION = '0.2.2'
+VERSION = '0.2.3'
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ Output = collections.namedtuple('Output', ['separated_mask', 'figure'])
 def main(mask, intensity_image, min_area, max_area,
         min_cut_area, max_circularity, max_convexity,
         plot=False, selection_test_mode=False,
-        selection_test_show_remaining=False):
+        selection_test_show_remaining=False, trimming = True):
     '''Detects clumps in `mask` given criteria provided by the user
     and cuts them along the borders of watershed regions, which are determined
     based on the distance transform of `mask`.
@@ -70,6 +70,9 @@ def main(mask, intensity_image, min_area, max_area,
         after the cuts were performed (helps to see why some objects were not
         cut, especially if there are complicated clumps that require multiple
         cuts). Defaults to false, thus showing the values in the original image
+    trimming: bool
+        some cuts may create a tiny third object. If this boolean is true, 
+        tertiary objects < trimming_threshold (10) pixels will be removed
 
     Returns
     -------
@@ -78,7 +81,7 @@ def main(mask, intensity_image, min_area, max_area,
 
     separated_mask = separate_clumped_objects(
         mask, min_cut_area, min_area, max_area,
-        max_circularity, max_convexity
+        max_circularity, max_convexity, allow_trimming = trimming
     )
 
     if plot:

--- a/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/separate_clumps.py
@@ -28,7 +28,7 @@ VERSION = '0.2.3'
 
 logger = logging.getLogger(__name__)
 
-Output = collections.namedtuple('Output', ['separated_mask', 'figure'])
+Output = collections.namedtuple('Output', ['separated_label_image', 'figure'])
 
 
 
@@ -79,7 +79,7 @@ def main(mask, intensity_image, min_area, max_area,
     jtmodules.separate_clumps.Output
     '''
 
-    separated_mask = separate_clumped_objects(
+    separated_label_image = separate_clumped_objects(
         mask, min_cut_area, min_area, max_area,
         max_circularity, max_convexity, allow_trimming = trimming
     )
@@ -91,10 +91,10 @@ def main(mask, intensity_image, min_area, max_area,
         initial_objects_label_image, n_initial_objects = mh.label(mask > 0)
         for n in range(1, n_initial_objects+1):
             obj = (initial_objects_label_image == n)
-            if len(np.unique(separated_mask[obj])) > 1:
+            if len(np.unique(separated_label_image[obj])) > 1:
                 clumps_mask[obj] = True
 
-        cut_mask = (mask > 0) & (separated_mask == 0)
+        cut_mask = (mask > 0) & (separated_label_image == 0)
         cutlines = mh.morph.dilate(mh.labeled.bwperim(cut_mask))
 
         if selection_test_mode:
@@ -103,7 +103,7 @@ def main(mask, intensity_image, min_area, max_area,
             # Check if selection_test_show_remaining is active
             # If so, show values on processed image, not original
             if selection_test_show_remaining:
-                labeled_mask, n_objects = mh.label(separated_mask > 0)
+                labeled_mask, n_objects = mh.label(separated_label_image > 0)
                 logger.info('Selection test mode plot with processed image')
             else:
                 labeled_mask, n_objects = mh.label(mask)
@@ -145,14 +145,14 @@ def main(mask, intensity_image, min_area, max_area,
         else:
             logger.info('create plot')
 
-            n_objects = len(np.unique(separated_mask[separated_mask > 0]))
+            n_objects = len(np.unique(separated_label_image[separated_label_image > 0]))
             colorscale = plotting.create_colorscale(
                 'Spectral', n=n_objects, permute=True, add_background=True
             )
-            outlines = mh.morph.dilate(mh.labeled.bwperim(separated_mask > 0))
+            outlines = mh.morph.dilate(mh.labeled.bwperim(separated_label_image > 0))
             plots = [
                 plotting.create_mask_image_plot(
-                    separated_mask, 'ul', colorscale=colorscale
+                    separated_label_image, 'ul', colorscale=colorscale
                 ),
                 plotting.create_intensity_overlay_image_plot(
                     intensity_image, outlines, 'ur'
@@ -167,4 +167,4 @@ def main(mask, intensity_image, min_area, max_area,
     else:
         figure = str()
 
-    return Output(separated_mask, figure)
+    return Output(separated_label_image, figure)


### PR DESCRIPTION
Made the cutting line thinner, fixed bug in nuclei separation, added an option to remove very small objects created through the cutting and cleaned up the module.

The cutting line was shifted by 1 pixel in x & y from where it should have been. This lead to the module sometimes creating additional, tiny objects.

This was also the reason that a line dilation was necessary to ensure separation of the objects. After fixing the line shifting bug, removing the line dilation doesn't interfere with nuclei being separated, but makes the separation line narrower.

Still, the module can sometimes create tiny objects through a cut and would then not perform the cut. Instead, the new default is to remove the tiny object (if it's smaller than 10 pixels in area).

Also, there were various lines not being used anymore and the output of the module was called a mask even though it was a label image. These things were fixed here as well.

As there were this many changes and a new input was added to the module, the module version number is increased from 0.2.2 to 0.2.3. If one updates an existing instance, the value in the handles file needs to be corrected (or the module removed from the pipeline and added again).